### PR TITLE
Inclusão de testes unitários para os métodos add_partition() e repartition_dataframe() da classe GlueETLManager

### DIFF
--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -6,3 +6,5 @@ markers =
     etl_manager: testes relacionados à classe GlueETLManager responsável por fornecer métodos de transformação de dados e operações gerais utilizando o Glue
     terraform: testes relacionados à declarações do usuário em arquivos Terraform usados para criação de recursos na nuvem
     date_attributes_extraction: testes relacionados ao método date_attributes_extraction da classe GlueETLManager
+    add_partition: testes relacionados ao método add_partition da classe GlueETLManager
+    repartition_dataframe: testes relacionados ao método repartition_dataframe da classe GlueETLManager


### PR DESCRIPTION
:bookmark_tabs: **_Descrição do PR:_**
PR com o objetivo de atualizar a branch main do repositório com um kit intermediário contento testes unitários para as funcionalidades caracterizadas como **métodos estáticos** da classe `GlueETLManager`.
___
:link: **_Issues contempladas:_**
Este Pull Request considera e eventualmente encerra as issues:
#12 
___
:hammer: **_Tarefas realizadas:_**
- Finalização de testes unitários para o método `date_attributes_extraction()`
- Finalização de testes unitários para o método `add_partition()`
- Finalização de testes unitários para o método `repartition_dataframe()`
___
:heavy_check_mark: **_Checklist:_**
- [x] O código desenvolvido seguiu as boas práticas contidas no repositório
- [x] As funcionalidades foram testadas adequadamente
- [x] Não existe risco de comprometimento do projeto como um todo
